### PR TITLE
Fixed issues with udacity link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A note about order - I framed the contents in the Pipeline & Tools section order
 
 ### Data Science Courses:
 * [Coursera](https://www.coursera.org/specialization/jhudatascience/1) - Data Science Specialization at Coursera - many other courses available as well.
-* [Udacity](https://www.udacity.com/courses#!/data-science) - Online MOOCs that are the Data Science related courses. by I
+* [Udacity](https://www.udacity.com/course/data-scientist-nanodegree--nd025) - Data Science Nanodegree progam - many other data science programs also.
 * [Data Science Bootcamps](http://yet-another-data-blog.blogspot.com/2014/04/data-science-bootcamp-landscape-full.html) - A collection of all bootcamps currently on the market as of April 5, 2014 by Ikechukwu Okonkwo.
 * [Coursera Machine Learning Course](https://www.coursera.org/course/ml) - Andrew Ng's pinnacle Machine Learning course.
 * [Edx](https://www.edx.org/course/mitx/mitx-6-00-2x-introduction-computational-2836#.VEANx9TF-tw) - EDX courses related to data science.


### PR DESCRIPTION
The previous udacity link isn’t functional anymore. 
Added the udacity data science nano degree program link 